### PR TITLE
Fix buffer overflow in M_LoadDefaults

### DIFF
--- a/Source/m_misc.c
+++ b/Source/m_misc.c
@@ -469,7 +469,7 @@ void M_LoadDefaults (void)
     while (!feof(f))
     {
       isstring = false;
-      if (fscanf (f, "%79s %[^\n]\n", def, strparm) == 2)
+      if (fscanf (f, "%79s %99[^\n]\n", def, strparm) == 2)
       {
 	if (strparm[0] == '"')
 	{


### PR DESCRIPTION
If `fscanf` doesn't limit the number of characters to be read, it can lead to a buffer overflow which allows for arbitrary code execution. 

CVE-2020-15007: https://nvd.nist.gov/vuln/detail/CVE-2020-15007